### PR TITLE
Feat/shop find

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-devtools'
-	
+
+	// MySQL dependence
+	implementation 'com.mysql:mysql-connector-j:8.0.33'
+
+
 	// SpringDoc OpenAPI 3
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
@@ -37,7 +41,7 @@ dependencies {
 	implementation 'org.modelmapper:modelmapper:3.2.0'
 	
 	// H2 데이터베이스 (개발/테스트용)
-	runtimeOnly 'com.h2database:h2'
+	//runtimeOnly 'com.h2database:h2'
 	
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/umc/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/umc/domain/shop/controller/ShopController.java
@@ -1,0 +1,30 @@
+package com.umc.domain.shop.controller;
+
+import com.umc.domain.shop.dto.ShopResponseDto;
+import com.umc.domain.shop.entity.Shop;
+import com.umc.domain.shop.service.ShopService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/shops")
+@RequiredArgsConstructor
+public class ShopController {
+
+    private final ShopService shopService;
+
+    @GetMapping("/nearby")
+    public List<ShopResponseDto> getNearbyShops(
+            @RequestParam double lat,
+            @RequestParam double lng,
+            @RequestParam(defaultValue = "2.0") double radius, // km 단위
+            @RequestParam(defaultValue = "5") int limit
+    ) {
+        List<Shop> shops = shopService.findNearbyShops(lat, lng, radius, limit);
+        return shops.stream()
+                .map(ShopResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/umc/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/umc/domain/shop/controller/ShopController.java
@@ -1,7 +1,6 @@
 package com.umc.domain.shop.controller;
 
 import com.umc.domain.shop.dto.ShopResponseDto;
-import com.umc.domain.shop.entity.Shop;
 import com.umc.domain.shop.service.ShopService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -18,13 +17,8 @@ public class ShopController {
     @GetMapping("/nearby")
     public List<ShopResponseDto> getNearbyShops(
             @RequestParam double lat,
-            @RequestParam double lng,
-            @RequestParam(defaultValue = "2.0") double radius, // km 단위
-            @RequestParam(defaultValue = "5") int limit
+            @RequestParam double lng
     ) {
-        List<Shop> shops = shopService.findNearbyShops(lat, lng, radius, limit);
-        return shops.stream()
-                .map(ShopResponseDto::from)
-                .toList();
+        return shopService.findNearbyShops(lat, lng);
     }
 }

--- a/src/main/java/com/umc/domain/shop/dto/ShopResponseDto.java
+++ b/src/main/java/com/umc/domain/shop/dto/ShopResponseDto.java
@@ -1,0 +1,32 @@
+package com.umc.domain.shop.dto;
+
+import com.umc.domain.shop.entity.Shop;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShopResponseDto {
+
+    private Long id;
+    private String title;
+    private String contact;
+    private String address;
+    private String shopUrl;
+    private String description;
+    private Double latitude;
+    private Double longitude;
+
+    public static ShopResponseDto from(Shop shop) {
+        return ShopResponseDto.builder()
+                .id(shop.getId())
+                .title(shop.getTitle())
+                .contact(shop.getContact())
+                .address(shop.getAddress())
+                .shopUrl(shop.getShopUrl())
+                .description(shop.getDescription())
+                .latitude(shop.getLatitude())
+                .longitude(shop.getLongitude())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/domain/shop/entity/Shop.java
+++ b/src/main/java/com/umc/domain/shop/entity/Shop.java
@@ -28,8 +28,10 @@ public class Shop {
     @Column(columnDefinition = "TEXT")
     private String description;
 
+    @Column(nullable = false)
     private Double latitude;
 
+    @Column(nullable = false)
     private Double longitude;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/umc/domain/shop/entity/Shop.java
+++ b/src/main/java/com/umc/domain/shop/entity/Shop.java
@@ -1,0 +1,48 @@
+package com.umc.domain.shop.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "shop")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Shop {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String contact;
+
+    private String address;
+
+    private String shopUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/umc/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/umc/domain/shop/repository/ShopRepository.java
@@ -1,0 +1,17 @@
+package com.umc.domain.shop.repository;
+
+import com.umc.domain.shop.entity.Shop;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ShopRepository extends JpaRepository<Shop, Long> {
+
+    // 위도/경도 기반 검색 (간단히 계산하는 버전)
+    List<Shop> findByLatitudeBetweenAndLongitudeBetween(
+            double minLat, double maxLat,
+            double minLng, double maxLng
+    );
+}

--- a/src/main/java/com/umc/domain/shop/service/ShopService.java
+++ b/src/main/java/com/umc/domain/shop/service/ShopService.java
@@ -1,0 +1,9 @@
+package com.umc.domain.shop.service;
+
+import com.umc.domain.shop.entity.Shop;
+
+import java.util.List;
+
+public interface ShopService {
+    List<Shop> findNearbyShops(double centerLat, double centerLng, double radiusKm, int limit);
+}

--- a/src/main/java/com/umc/domain/shop/service/ShopService.java
+++ b/src/main/java/com/umc/domain/shop/service/ShopService.java
@@ -1,9 +1,10 @@
 package com.umc.domain.shop.service;
 
-import com.umc.domain.shop.entity.Shop;
+import com.umc.domain.shop.dto.ShopResponseDto;
 
 import java.util.List;
 
 public interface ShopService {
-    List<Shop> findNearbyShops(double centerLat, double centerLng, double radiusKm, int limit);
+    // 반경, 리밋은 내부에서 고정 (예: 5km, 5개)
+    List<ShopResponseDto> findNearbyShops(double latitude, double longitude);
 }

--- a/src/main/java/com/umc/domain/shop/service/ShopServiceImpl.java
+++ b/src/main/java/com/umc/domain/shop/service/ShopServiceImpl.java
@@ -23,6 +23,11 @@ public class ShopServiceImpl implements ShopService {
         double minLng = centerLng - delta;
         double maxLng = centerLng + delta;
 
+        System.out.println("lat: " + centerLat);
+        System.out.println("lng: " + centerLng);
+
+
+
         // 범위 내 가게 조회
         List<Shop> shops = shopRepository.findByLatitudeBetweenAndLongitudeBetween(
                 minLat, maxLat, minLng, maxLng

--- a/src/main/java/com/umc/domain/shop/service/ShopServiceImpl.java
+++ b/src/main/java/com/umc/domain/shop/service/ShopServiceImpl.java
@@ -1,0 +1,34 @@
+package com.umc.domain.shop.service;
+
+import com.umc.domain.shop.entity.Shop;
+import com.umc.domain.shop.repository.ShopRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShopServiceImpl implements ShopService {
+
+    private final ShopRepository shopRepository;
+
+    @Override
+    public List<Shop> findNearbyShops(double centerLat, double centerLng, double radiusKm, int limit) {
+        // 반경 → 위도/경도 범위 변환
+        double delta = radiusKm / 111.0;
+
+        double minLat = centerLat - delta;
+        double maxLat = centerLat + delta;
+        double minLng = centerLng - delta;
+        double maxLng = centerLng + delta;
+
+        // 범위 내 가게 조회
+        List<Shop> shops = shopRepository.findByLatitudeBetweenAndLongitudeBetween(
+                minLat, maxLat, minLng, maxLng
+        );
+
+        // limit 개수만 자르기
+        return shops.size() > limit ? shops.subList(0, limit) : shops;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,37 +5,3 @@ spring:
   profiles:
     active: dev
 
-  # 데이터베이스 설정 (H2 인메모리)
-  datasource:
-    url: jdbc:h2:mem:umc-hackathon
-    driver-class-name: org.h2.Driver
-    username: sa
-    password: ""
-
-  # JPA/Hibernate 설정
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
-
-  # H2 콘솔 설정 (개발용)
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  # Thymeleaf 설정
-  thymeleaf:
-    cache: false
-
-server:
-  port: 8080
-
-# 로깅 설정
-logging:
-  level:
-    com.umc: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,15 +11,16 @@ spring:
     username: root
     password: cjswoshckd44!
 
-  # JPA/Hibernate 설정
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
+        id:
+          new_generator_mappings: false  # <-- 이거 추가
 
   # H2 콘솔 설정 (개발용)
   h2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,38 @@ spring:
   profiles:
     active: dev
 
+  # 데이터베이스 설정 (H2 인메모리)
+  datasource:
+    url: jdbc:mysql://localhost:3306/hack
+    username: root
+    password: cjswoshckd44!
+
+  # JPA/Hibernate 설정
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+
+  # H2 콘솔 설정 (개발용)
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+
+
+  # Thymeleaf 설정
+  thymeleaf:
+    cache: false
+
+server:
+  port: 8080
+
+# 로깅 설정
+logging:
+  level:
+    com.umc: DEBUG


### PR DESCRIPTION
## 📌 PR 요약

Shop 도메인 기능 구현 – 반경 기반 향수 공방 조회 API 및 관련 Entity/DTO/Service 구성.  
프론트엔드에서 유저 위치 기반으로 주변 향수 공방 정보를 받아올 수 있도록 API 구현.

---

## 📑 작업 내용

1. Shop Entity 생성
   - id, 상호명, 연락처, 주소, 위도/경도, 설명, 링크 등의 필드 포함
   - `@PrePersist`, `@PreUpdate`로 자동 시간 필드 처리

2. Shop 더미 데이터 삽입 및 로컬 DB 연동 확인
   - MySQL + DataGrip 연동
   - `ddl-auto: update` 설정으로 실행 시 데이터 보존

3. ShopRepository 생성
   - 위도/경도 기반 가게 검색 메서드 정의
   - `findByLatitudeBetweenAndLongitudeBetween()` 사용

4. ShopService / ShopServiceImpl 작성
   - 위도/경도 기반 공방 거리 정렬 + 상위 5개 필터링
   - 전국 단위 커버 가능하도록 넓은 범위 지정

5. ShopResponseDto 생성
   - 필요한 필드만 응답으로 전달
   - Entity → DTO 변환 `from()` 메서드 구현

6. ShopController 생성
   - `/api/shops/nearby` GET API 구현
   - 위도(`lat`)와 경도(`lng`)를 쿼리로 받아 응답 반환

7. Swagger 설정 완료
   - Swagger UI에서 API 호출 확인 및 테스트 완료

---

## 💡 추가 참고 사항

- 거리 계산은 유클리드 방식(`Point2D.distance`)으로, 추후 Haversine 방식으로 개선 가능
- 현재 모든 shop 중 거리 정렬 → 추후 성능 최적화 고려
- 프론트는 `lat`, `lng`만 넘기면 되도록 설계
- 향후 결과에 거리(distance) 포함 여부 협의 필요
