### PR TITLE
Feat/review create

### DIFF
--- a/src/main/java/com/umc/auth/Jwt/JwtProvider.java
+++ b/src/main/java/com/umc/auth/Jwt/JwtProvider.java
@@ -1,10 +1,16 @@
 package com.umc.auth.Jwt;
 
 import com.umc.domain.user.entity.User;
+import com.umc.global.exception.ErrorCode;
+import com.umc.global.exception.GlobalExceptionHandler;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;

--- a/src/main/java/com/umc/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/domain/review/controller/ReviewController.java
@@ -5,7 +5,11 @@ import com.umc.common.response.ApiResponse;
 import com.umc.domain.review.dto.ReviewRequestDTO;
 import com.umc.domain.review.dto.ReviewResponseDTO;
 import com.umc.domain.review.service.ReviewService;
+import com.umc.global.exception.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,8 +27,21 @@ public class ReviewController {
             @RequestHeader("Authorization") String token,
             @RequestBody ReviewRequestDTO.CreatReviewRequestDTO request
     ) {
+
+        /*
+        // 1. 향수 존재 여부 확인 -> 향수 엔티티 추가시 다시
+        if (!perfumeRepository.existsById(perfumeId)) {
+            return ResponseEntity.status(ErrorCode.PERFUME_NOT_FOUND.getStatus()).build();
+        }*/
+
+        // 2. JWT 유효성 검사 및 사용자 ID 추출
         String parsedToken = token.replace("Bearer ", "");
-        Long userId = jwtTokenProvider.getUserId(parsedToken);
+        Long userId;
+        try {
+            userId = jwtTokenProvider.getUserId(parsedToken);
+        } catch (JwtException | IllegalArgumentException e) {
+            return ResponseEntity.status(ErrorCode.TOKEN_INVALID.getStatus()).build();
+        }
 
         ReviewResponseDTO.CreateReviewReponseDTO result = reviewService.createReview(perfumeId, userId, request);
 

--- a/src/main/java/com/umc/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/domain/review/controller/ReviewController.java
@@ -1,0 +1,33 @@
+package com.umc.domain.review.controller;
+
+import com.umc.auth.Jwt.JwtProvider;
+import com.umc.common.response.ApiResponse;
+import com.umc.domain.review.dto.ReviewRequestDTO;
+import com.umc.domain.review.dto.ReviewResponseDTO;
+import com.umc.domain.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+    private final JwtProvider jwtTokenProvider;
+
+    @PostMapping("/{perfumeId}")
+    public ResponseEntity<ApiResponse<ReviewResponseDTO.CreateReviewReponseDTO>> createReview(
+            @PathVariable Long perfumeId,
+            @RequestHeader("Authorization") String token,
+            @RequestBody ReviewRequestDTO.CreatReviewRequestDTO request
+    ) {
+        String parsedToken = token.replace("Bearer ", "");
+        Long userId = jwtTokenProvider.getUserId(parsedToken);
+
+        ReviewResponseDTO.CreateReviewReponseDTO result = reviewService.createReview(perfumeId, userId, request);
+
+        return ResponseEntity.ok(ApiResponse.success("리뷰가 성공적으로 등록되었습니다.", result));
+    }
+}

--- a/src/main/java/com/umc/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/umc/domain/review/converter/ReviewConverter.java
@@ -1,0 +1,33 @@
+package com.umc.domain.review.converter;
+
+
+import com.umc.domain.review.dto.ReviewRequestDTO;
+import com.umc.domain.review.dto.ReviewResponseDTO;
+import com.umc.domain.review.entity.Review;
+import com.umc.domain.user.entity.User;
+
+public class ReviewConverter {
+
+    public static Review toEntity(Long perfumeId, Long userId, ReviewRequestDTO.CreatReviewRequestDTO request) {
+        return Review.builder()
+                .perfumeId(perfumeId)
+                .userId(userId)
+                .description(request.getDescription())
+                .build();
+    }
+
+    public static ReviewResponseDTO.CreateReviewReponseDTO toCreateDTO(Review review, User user) {
+        return ReviewResponseDTO.CreateReviewReponseDTO.builder()
+                .id(review.getId())
+                .description(review.getDescription())
+                .user(
+                        ReviewResponseDTO.UserDTO.builder()
+                                .id(user.getId())
+                                .nickname(user.getNickname())
+                                .build()
+                )
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/umc/domain/review/dto/ReviewRequestDTO.java
@@ -1,0 +1,24 @@
+package com.umc.domain.review.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class ReviewRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreatReviewRequestDTO {
+        private String description;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+}

--- a/src/main/java/com/umc/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/umc/domain/review/dto/ReviewResponseDTO.java
@@ -1,0 +1,32 @@
+package com.umc.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ReviewResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateReviewReponseDTO {
+        private Long id;
+        private String description;
+        private UserDTO user;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserDTO {
+        private Long id;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/umc/domain/review/entity/Review.java
+++ b/src/main/java/com/umc/domain/review/entity/Review.java
@@ -1,0 +1,24 @@
+package com.umc.domain.review.entity;
+
+import com.umc.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "reviews")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Review extends BaseEntity {
+
+    private Long perfumeId; // 연관관계 대신 ID만 저장
+
+    private Long userId;
+
+    private String description;
+}
+
+
+

--- a/src/main/java/com/umc/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/umc/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,14 @@
+package com.umc.domain.review.repository;
+
+import com.umc.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findAllByPerfumeIdOrderByCreatedAtDesc(Long perfumeId);
+    List<Review> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/umc/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/domain/review/service/ReviewService.java
@@ -1,0 +1,31 @@
+package com.umc.domain.review.service;
+
+import com.umc.domain.review.converter.ReviewConverter;
+import com.umc.domain.review.dto.ReviewRequestDTO;
+import com.umc.domain.review.dto.ReviewResponseDTO;
+import com.umc.domain.review.entity.Review;
+import com.umc.domain.review.repository.ReviewRepository;
+import com.umc.domain.user.entity.User;
+import com.umc.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ReviewResponseDTO.CreateReviewReponseDTO createReview(Long perfumeId, Long userId, ReviewRequestDTO.CreatReviewRequestDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Review review = ReviewConverter.toEntity(perfumeId, userId, request);
+        Review saved = reviewRepository.save(review);
+
+        return ReviewConverter.toCreateDTO(saved, user);
+    }
+}

--- a/src/main/java/com/umc/global/exception/ErrorCode.java
+++ b/src/main/java/com/umc/global/exception/ErrorCode.java
@@ -17,8 +17,14 @@ public enum ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_001", "입력값 검증에 실패했습니다."),
     REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "VALIDATION_002", "필수 필드가 누락되었습니다."),
 
-    //
-    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "BUSINESS_002", "이미 존재하는 닉네임입니다. 비밀번호를 다시 ");
+    // 로그인 관련 에러
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "BUSINESS_002", "이미 존재하는 닉네임입니다. 비밀번호를 다시 입력해주세요."),
+
+    // 토큰 관련 에러
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 토큰입니다."),
+
+    // 향수 관련 에러
+    PERFUME_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFUME_001", "해당 향수를 찾을 수 없습니다.");
 
     // TODO: 비즈니스 로직 개발하면서 필요한 에러코드들 추가
 


### PR DESCRIPTION
📌 PR 요약

리뷰 작성 API를 구현하여 사용자가 특정 향수에 대한 리뷰를 등록할 수 있도록 기능을 추가했습니다. 향수 존재 여부 및 JWT 토큰 유효성 검사는 컨트롤러에서 수행하며, 예외는  에러 코드로 처리됩니다.

📑 작업 내용

1. ReviewController 생성 및 리뷰 작성 엔드포인트(/api/reviews/perfumes/{perfumeId}) 구현
2. 리뷰 작성 요청 및 응답 DTO (ReviewRequestDTO, ReviewResponseDTO) 생성
3. Review 엔티티 정의 (연관관계 없이 perfumeId, userId만 저장)
4. ReviewConverter 클래스 구현 (Builder 기반 DTO ↔ Entity 변환)
5. ReviewService 서비스 계층 구현 (createReview)
6. 향수 존재 여부 확인 (perfumeRepository.existsById) 및 예외 처리 주석 처리 (향수 domain 생성 후 주석 처리 취소 예정) 
7. 예외 발생 시 Exception + ErrorCode 사용
8. ErrorCode에 PERFUME_NOT_FOUND, TOKEN_INVALID 추가

스크린샷
<img width="1470" alt="스크린샷 2025-07-06 오전 12 57 08" src="https://github.com/user-attachments/assets/3b83139a-b750-4a59-8199-96bb75ad69bf" />

<img width="1470" alt="스크린샷 2025-07-06 오전 12 57 04" src="https://github.com/user-attachments/assets/6ed7d7bd-7e13-4ba4-b8dd-c2d8a62837b9" />


💡 추가 참고 사항

컨트롤러에서 향수 존재 여부, JWT 유효성 체크를 직접 수행
추후 리뷰 목록 조회, 수정, 삭제 API 구현 예정
테스트 환경에서는 샘플 향수 데이터를 직접 생성해야 함 (PerfumeRepository.save() 등으로 더미 데이터 입력 필요)
