### PR TITLE
feat: 특정 향수의 리뷰 목록 조회 api 생성

### DIFF
--- a/src/main/java/com/umc/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/domain/review/controller/ReviewController.java
@@ -13,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/reviews")
 @RequiredArgsConstructor
@@ -46,5 +48,15 @@ public class ReviewController {
         ReviewResponseDTO.CreateReviewReponseDTO result = reviewService.createReview(perfumeId, userId, request);
 
         return ResponseEntity.ok(ApiResponse.success("리뷰가 성공적으로 등록되었습니다.", result));
+    }
+
+    @GetMapping("/{perfumeId}")
+    public ResponseEntity<ApiResponse<List<ReviewResponseDTO.ReviewSimpleDTO>>> getReviewsByPerfume(
+            @PathVariable Long perfumeId) {
+        List<ReviewResponseDTO.ReviewSimpleDTO> result = reviewService.getReviewsByPerfumeId(perfumeId);
+
+        //에러처리 나중에 추가 예정
+
+        return ResponseEntity.ok(ApiResponse.success("리뷰 목록 조회 성공", result));
     }
 }

--- a/src/main/java/com/umc/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/umc/domain/review/converter/ReviewConverter.java
@@ -30,4 +30,14 @@ public class ReviewConverter {
                 .updatedAt(review.getUpdatedAt())
                 .build();
     }
+
+    public static ReviewResponseDTO.ReviewSimpleDTO toReviewSimpleDTO(Review review, String nickname) {
+        return ReviewResponseDTO.ReviewSimpleDTO.builder()
+                .id(review.getId())
+                .description(review.getDescription())
+                .user(new ReviewResponseDTO.UserDTO(review.getUserId(), nickname))
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/umc/domain/review/dto/ReviewResponseDTO.java
@@ -29,4 +29,16 @@ public class ReviewResponseDTO {
         private Long id;
         private String nickname;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewSimpleDTO { // 특정 향수의 리뷰 목록 조회
+        private Long id;
+        private String description;
+        private UserDTO user;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
 }

--- a/src/main/java/com/umc/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/umc/domain/review/repository/ReviewRepository.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    List<Review> findAllByPerfumeIdOrderByCreatedAtDesc(Long perfumeId);
     List<Review> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    List<Review> findByPerfumeIdOrderByCreatedAtDesc(Long perfumeId);
 }

--- a/src/main/java/com/umc/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/domain/review/service/ReviewService.java
@@ -11,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
@@ -27,5 +30,17 @@ public class ReviewService {
         Review saved = reviewRepository.save(review);
 
         return ReviewConverter.toCreateDTO(saved, user);
+    }
+
+    public List<ReviewResponseDTO.ReviewSimpleDTO> getReviewsByPerfumeId(Long perfumeId) {
+        List<Review> reviews = reviewRepository.findByPerfumeIdOrderByCreatedAtDesc(perfumeId);
+
+        return reviews.stream().map(review -> {
+            String nickname = userRepository.findById(review.getUserId())
+                    .map(User::getNickname)
+                    .orElse("알 수 없음");
+
+            return ReviewConverter.toReviewSimpleDTO(review, nickname);
+        }).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
📌 PR 요약

특정 향수에 대한 리뷰 목록을 조회하는 API를 구현했습니다.
요청 시 해당 향수에 작성된 모든 리뷰를 최신순으로 반환하며, 작성자 닉네임 정보도 함께 제공합니다.

📑 작업 내용

1. GET /api/reviews/{perfumeId} API 구현
2. ReviewResponseDTO.ReviewSimpleDTO 추가
3. ReviewConverter.toReviewSimpleDTO() 구현
4. ReviewService.getReviewsByPerfumeId() 구현
5. ReviewController.getReviewsByPerfume() 구현
6. ReviewRepository.findByPerfumeIdOrderByCreatedAtDesc() 메서드 추가


(예시 응답 포맷)

{
  "timestamp": "2025-06-30T01:43:07.956473",
  "status": 200,
  "code": "SUCCESS",
  "message": "리뷰 목록 조회 성공",
  "data": [
    {
      "id": 101,
      "description": "잔잔하고 따뜻한 향이에요.",
      "user": {
        "id": 3,
        "nickname": "softflower"
      },
      "createdAt": "2025-07-05T10:31:12.000000",
      "updatedAt": "2025-07-05T10:30:00.123456"
    }
  ]
}
💡 추가 참고 사항

현재는 Perfume 존재 여부를 별도 검증하지 않으며, 필요 시 PerfumeRepository.existsById()를 통해 선검증 추가 가능합니다.

