### PR TITLE
feat: 퍼퓸 모듈 추가 및 의존성 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Jackson JSR310 모듈 (LocalDateTime 직렬화 지원)
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/domain/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/umc/domain/perfume/controller/PerfumeController.java
@@ -1,0 +1,88 @@
+package com.umc.domain.perfume.controller;
+
+import com.umc.common.response.ApiResponse;
+import com.umc.domain.perfume.dto.PerfumeResponseDto;
+import com.umc.domain.perfume.entity.SourceType;
+import com.umc.domain.perfume.service.PerfumeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/perfumes")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "향수 API", description = "향수 생성 및 조회 API")
+public class PerfumeController {
+
+    private final PerfumeService perfumeService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+        summary = "향수 생성",
+        description = "오디오 또는 이미지 파일을 업로드하여 향수 정보를 생성합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "향수 생성 성공",
+            content = @Content(schema = @Schema(implementation = PerfumeResponseDto.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "500",
+            description = "서버 오류"
+        )
+    })
+    public ApiResponse<PerfumeResponseDto> createPerfume(
+            @Parameter(description = "소스 타입 (AUDIO 또는 IMAGE)")
+            @RequestParam("sourceType") SourceType sourceType,
+            
+            @Parameter(description = "업로드할 파일 (오디오 또는 이미지)")
+            @RequestParam("file") MultipartFile file) {
+        
+        log.info("향수 생성 요청 - sourceType: {}, fileName: {}", sourceType, file.getOriginalFilename());
+        
+        PerfumeResponseDto response = perfumeService.createPerfume(sourceType, file);
+        
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "향수 조회",
+        description = "향수 ID로 향수 정보를 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "향수 조회 성공",
+            content = @Content(schema = @Schema(implementation = PerfumeResponseDto.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "향수를 찾을 수 없음"
+        )
+    })
+    public ApiResponse<PerfumeResponseDto> getPerfume(
+            @Parameter(description = "향수 ID")
+            @PathVariable Long id) {
+        
+        log.info("향수 조회 요청 - id: {}", id);
+        
+        PerfumeResponseDto response = perfumeService.getPerfume(id);
+        
+        return ApiResponse.success(response);
+    }
+} 

--- a/src/main/java/com/umc/domain/perfume/dto/PerfumeDescriptionDto.java
+++ b/src/main/java/com/umc/domain/perfume/dto/PerfumeDescriptionDto.java
@@ -1,0 +1,44 @@
+package com.umc.domain.perfume.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.umc.domain.perfume.entity.SourceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "향수 설명 정보")
+public class PerfumeDescriptionDto {
+
+    @Schema(description = "소스 타입", example = "AUDIO")
+    private SourceType type;
+
+    @Schema(description = "파일 설명", example = "경쾌하고 밝은 멜로디의 팝송으로, 행복하고 에너지 넘치는 분위기를 담고 있습니다.")
+    @JsonProperty("fileDescription")
+    private String fileDescription;
+
+    @Schema(description = "탑노트", example = "[\"베르가못\", \"레몬\", \"오렌지\"]")
+    private List<String> top;
+
+    @Schema(description = "미들노트", example = "[\"로즈\", \"자스민\", \"라벤더\"]")
+    private List<String> middle;
+
+    @Schema(description = "베이스노트", example = "[\"머스크\", \"샌달우드\", \"바닐라\"]")
+    private List<String> base;
+
+    @Schema(description = "해석", example = "밝고 경쾌한 멜로디가 주는 따뜻한 감성을 표현한 향수로, 상쾌한 시트러스 노트가 로맨틱한 플로럴과 조화를 이루며 부드러운 우디 베이스로 마무리됩니다.")
+    private String interpretation;
+
+    @Schema(description = "요약", example = "행복과 설렘을 담은 시트러스 플로럴 향수")
+    private String summary;
+
+    @Schema(description = "제목", example = "Sunny Melody : 행복의 멜로디")
+    private String title;
+}

--- a/src/main/java/com/umc/domain/perfume/dto/PerfumeResponseDto.java
+++ b/src/main/java/com/umc/domain/perfume/dto/PerfumeResponseDto.java
@@ -1,0 +1,73 @@
+package com.umc.domain.perfume.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.domain.perfume.entity.Perfume;
+import com.umc.domain.perfume.entity.SourceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+@Schema(description = "향수 응답")
+public class PerfumeResponseDto {
+
+    @Schema(description = "향수 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "소스 타입", example = "AUDIO")
+    private SourceType sourceType;
+
+    @Schema(description = "향수 상세 정보")
+    private PerfumeDescriptionDto description;
+
+    @Schema(description = "파일 URL", example = "https://example.com/file.mp3")
+    private String url;
+
+    @Schema(description = "사용자 정보")
+    private UserInfo user;
+
+    @Schema(description = "생성 시간")
+    @JsonProperty("createdAt")
+    private String createdAt;
+
+    @Schema(description = "수정 시간")
+    @JsonProperty("updatedAt")
+    private String updatedAt;
+
+    @Getter
+    @Builder
+    @Schema(description = "사용자 정보")
+    public static class UserInfo {
+        @Schema(description = "사용자 ID", example = "123")
+        private Long id;
+
+        @Schema(description = "사용자 닉네임", example = "user123")
+        private String nickname;
+    }
+
+    public static PerfumeResponseDto from(Perfume perfume) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            PerfumeDescriptionDto descriptionDto = objectMapper.readValue(perfume.getDescription(), PerfumeDescriptionDto.class);
+            
+            return PerfumeResponseDto.builder()
+                    .id(perfume.getId())
+                    .sourceType(perfume.getSourceType())
+                    .description(descriptionDto)
+                    .url(perfume.getUrl())
+                    .user(UserInfo.builder()
+                            .id(1L) // 임시 사용자 ID
+                            .nickname("user123") // 임시 닉네임
+                            .build())
+                    .createdAt(perfume.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                    .updatedAt(perfume.getUpdatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("향수 설명 JSON 파싱에 실패했습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/umc/domain/perfume/entity/Perfume.java
+++ b/src/main/java/com/umc/domain/perfume/entity/Perfume.java
@@ -1,0 +1,25 @@
+package com.umc.domain.perfume.entity;
+
+import com.umc.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "perfume")
+@Getter
+@Setter
+public class Perfume extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false)
+    private SourceType sourceType;
+
+    @Column(name = "description", columnDefinition = "JSON")
+    private String description; // JSON 형태로 저장될 설명 데이터
+
+    @Column(name = "url", nullable = false)
+    private String url; // 소스 URL (오디오/이미지 파일 경로)
+
+    // BaseEntity에서 이미 id, createdAt, updatedAt을 상속받음
+}

--- a/src/main/java/com/umc/domain/perfume/entity/SourceType.java
+++ b/src/main/java/com/umc/domain/perfume/entity/SourceType.java
@@ -1,0 +1,6 @@
+package com.umc.domain.perfume.entity;
+
+public enum SourceType {
+    AUDIO,      // 오디오 소스
+    IMAGE       // 이미지 소스
+}

--- a/src/main/java/com/umc/domain/perfume/repository/PerfumeRepository.java
+++ b/src/main/java/com/umc/domain/perfume/repository/PerfumeRepository.java
@@ -1,0 +1,9 @@
+package com.umc.domain.perfume.repository;
+
+import com.umc.domain.perfume.entity.Perfume;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PerfumeRepository extends JpaRepository<Perfume, Long> {
+}

--- a/src/main/java/com/umc/domain/perfume/service/PerfumeGptService.java
+++ b/src/main/java/com/umc/domain/perfume/service/PerfumeGptService.java
@@ -1,0 +1,425 @@
+package com.umc.domain.perfume.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.domain.perfume.entity.SourceType;
+import com.umc.domain.perfume.entity.Perfume;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PerfumeGptService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    @Value("${openai.api.url:https://api.openai.com/v1/chat/completions}")
+    private String apiUrl;
+
+    @Value("${openai.transcription.url:https://api.openai.com/v1/audio/transcriptions}")
+    private String transcriptionUrl;
+
+    /**
+     * 향수 정보 전체 생성 프로세스
+     */
+    public Perfume generatePerfume(SourceType sourceType, String url, MultipartFile file) {
+        String description = generatePerfumeDescription(sourceType, file);
+        return createPerfumeEntity(sourceType, url, description);
+    }
+
+    /**
+     * 파일을 분석하여 향수 정보를 생성합니다.
+     */
+    public String generatePerfumeDescription(SourceType sourceType, MultipartFile file) {
+        try {
+            if (sourceType == SourceType.AUDIO) {
+                // 1. 음성을 텍스트로 변환 (가사 추출)
+                String lyrics = transcribeAudioToText(file);
+                log.info("추출된 가사: {}", lyrics);
+                
+                // 2. 가사를 분석하여 향수 레시피 생성
+                String prompt = createLyricsAnalysisPrompt(lyrics);
+                String gptResponse = callGptApiWithText(prompt);
+                
+                // GPT 응답에서 JSON 부분만 추출
+                String jsonResponse = extractJsonFromResponse(gptResponse);
+                
+                // JSON 유효성 검증
+                validateJsonResponse(jsonResponse);
+                
+                return jsonResponse;
+            } else {
+                // 이미지 파일 처리 (기존 방식)
+                String prompt = createImagePrompt();
+                String gptResponse = callGptApiWithImage(prompt, file);
+                
+                String jsonResponse = extractJsonFromResponse(gptResponse);
+                validateJsonResponse(jsonResponse);
+                
+                return jsonResponse;
+            }
+            
+        } catch (Exception e) {
+            log.error("GPT API 호출 중 오류 발생: ", e);
+            return getDefaultDescription(sourceType);
+        }
+    }
+
+    /**
+     * Whisper API를 사용하여 음성을 텍스트로 변환합니다.
+     */
+    private String transcribeAudioToText(MultipartFile audioFile) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            headers.setBearerAuth(apiKey);
+
+            // MultiValueMap을 사용하여 multipart/form-data 구성
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            
+            // 파일을 ByteArrayResource로 변환
+            ByteArrayResource fileResource = new ByteArrayResource(audioFile.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return audioFile.getOriginalFilename();
+                }
+            };
+            
+            body.add("file", fileResource);
+            body.add("model", "whisper-1");
+            body.add("language", "ko"); // 한국어 우선, 자동 감지도 가능
+            body.add("response_format", "json");
+            body.add("temperature", 0.2); // 낮은 temperature로 정확성 향상
+
+            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+            ResponseEntity<String> response = restTemplate.postForEntity(
+                transcriptionUrl, 
+                requestEntity, 
+                String.class
+            );
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return extractTranscriptionFromResponse(response.getBody());
+            } else {
+                log.warn("Whisper API 호출 실패: {}", response.getStatusCode());
+                throw new RuntimeException("음성 변환에 실패했습니다");
+            }
+
+        } catch (Exception e) {
+            log.error("음성 변환 중 오류: ", e);
+            throw new RuntimeException("음성을 텍스트로 변환하는 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Whisper API 응답에서 텍스트 추출
+     */
+    private String extractTranscriptionFromResponse(String responseBody) {
+        try {
+            JsonNode rootNode = objectMapper.readTree(responseBody);
+            String transcription = rootNode.path("text").asText();
+            
+            if (transcription == null || transcription.trim().isEmpty()) {
+                throw new RuntimeException("변환된 텍스트가 비어있습니다");
+            }
+            
+            return transcription.trim();
+            
+        } catch (Exception e) {
+            log.error("변환 응답 파싱 오류: ", e);
+            throw new RuntimeException("음성 변환 결과를 파싱하는데 실패했습니다");
+        }
+    }
+
+    /**
+     * 가사 분석을 위한 프롬프트 생성
+     */
+    private String createLyricsAnalysisPrompt(String lyrics) {
+        return String.format("""
+            당신은 전문 가사 분석가이자 향수 제작 전문가입니다. 
+            다음 가사를 분석하여 노래가 담고 있는 감정, 분위기, 메시지를 파악하고,
+            이를 바탕으로 향수 제작에 필요한 상세한 분석을 JSON 형태로 제공해주세요.
+            
+            === 분석할 가사 ===
+            %s
+            ==================
+            
+            위 가사를 분석하여 다음 요소들을 파악해주세요:
+            1. 전체적인 감정 (기쁨, 슬픔, 그리움, 사랑, 희망, 우울 등)
+            2. 분위기 (밝음, 어두움, 로맨틱, 에너제틱, 차분함 등)
+            3. 주요 테마와 이미지
+            4. 계절감이나 시간대
+            5. 색채감
+            
+            이 분석을 바탕으로 다음 JSON 형태로 응답해주세요:
+            {
+                "type": "AUDIO",
+                "fileDescription": "가사가 전달하는 감정과 분위기를 2-3문장으로 설명",
+                "top": ["탑노트 최대 3개"],
+                "middle": ["미들노트 최대 3개"],
+                "base": ["베이스노트 최대 3개"],
+                "interpretation": "향수의 전체적인 특징과 노트 조화를 설명하는 2-3문장",
+                "summary": "향수의 핵심 특징을 담은 짧은 문장",
+                "title": "향수 이름 : 부제목 형태"
+            }
+            
+            주의사항:
+            - JSON 형식을 정확히 지켜주세요
+            - 배열은 정확히 3개씩만 포함해주세요
+            - title: 25자 이내로 작성해주세요
+            - top/middle/base 노트: 각 항목당 4글자 이내 (예: 레몬, 장미, 바닐라 등)
+            - interpretation: 100자 이내로 작성해주세요
+            - 향수 노트는 실제 존재하는 향료명을 사용해주세요
+            - 가사의 감정과 이미지를 향수 노트로 창의적이고 적절하게 매핑해주세요
+            
+            감정-향료 매핑 가이드:
+            - 기쁨/밝음: 시트러스(레몬, 오렌지), 플로럴(로즈, 자스민)
+            - 사랑/로맨스: 플로럴(장미, 피오니), 바닐라, 머스크
+            - 그리움/슬픔: 우디(샌달우드, 시더), 스파이시(카다몸, 클로브)
+            - 신선함/청량감: 아쿠아틱, 그린(eucalyptus, 민트)
+            - 따뜻함/포근함: 바닐라, 앰버, 통카빈
+            - 신비로움: 오리엔탈(인센스, 패출리), 우드
+            """, lyrics);
+    }
+
+    /**
+     * 이미지 분석용 프롬프트
+     */
+    private String createImagePrompt() {
+        return """
+            당신은 전문 이미지 분석가이자 향수 제작 전문가입니다. 이 이미지를 향수 제작에 필요한 관점에서 상세히 분석하여 JSON 형태로 제공해주세요.
+            
+            다음 JSON 형태로 응답해주세요:
+            {
+                "type": "IMAGE",
+                "fileDescription": "이미지가 전달하는 감정과 분위기를 2-3문장으로 설명",
+                "top": ["탑노트 최대 3개"],
+                "middle": ["미들노트 최대 3개"],
+                "base": ["베이스노트 최대 3개"],
+                "interpretation": "향수의 전체적인 특징과 노트 조화를 설명하는 2-3문장",
+                "summary": "향수의 핵심 특징을 담은 짧은 문장",
+                "title": "향수 이름 : 부제목 형태"
+            }
+            
+            주의사항:
+            - JSON 형식을 정확히 지켜주세요
+            - 배열은 정확히 3개씩만 포함해주세요
+            - title: 25자 이내로 작성해주세요
+            - top/middle/base 노트: 각 항목당 4글자 이내
+            - interpretation: 100자 이내로 작성해주세요
+            - 향수 노트는 실제 존재하는 향료명을 사용해주세요
+            """;
+    }
+
+    /**
+     * GPT API 호출 (텍스트만)
+     */
+    private String callGptApiWithText(String prompt) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
+
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("model", "gpt-4o-mini");
+            requestBody.put("max_tokens", 600);
+            requestBody.put("temperature", 0.7);
+            requestBody.put("messages", List.of(
+                Map.of(
+                    "role", "user",
+                    "content", prompt
+                )
+            ));
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(apiUrl, entity, String.class);
+            
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return extractContentFromApiResponse(response.getBody());
+            } else {
+                log.warn("GPT-4o-mini 분석 실패: {}", response.getStatusCode());
+                throw new RuntimeException("GPT 분석에 실패했습니다");
+            }
+            
+        } catch (Exception e) {
+            log.error("GPT API 호출 중 오류: ", e);
+            throw new RuntimeException("GPT API 호출 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * GPT API 호출 (이미지 포함)
+     */
+    private String callGptApiWithImage(String prompt, MultipartFile file) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
+
+            String base64File = java.util.Base64.getEncoder().encodeToString(file.getBytes());
+            
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("model", "gpt-4o-mini");
+            requestBody.put("max_tokens", 600);
+            requestBody.put("temperature", 0.7);
+            requestBody.put("messages", List.of(
+                Map.of(
+                    "role", "user",
+                    "content", List.of(
+                        Map.of(
+                            "type", "text",
+                            "text", prompt
+                        ),
+                        Map.of(
+                            "type", "image_url",
+                            "image_url", Map.of(
+                                "url", "data:" + file.getContentType() + ";base64," + base64File
+                            )
+                        )
+                    )
+                )
+            ));
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(apiUrl, entity, String.class);
+            
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return extractContentFromApiResponse(response.getBody());
+            } else {
+                log.warn("GPT-4o-mini 이미지 분석 실패: {}", response.getStatusCode());
+                throw new RuntimeException("이미지 분석에 실패했습니다");
+            }
+            
+        } catch (Exception e) {
+            log.error("GPT API 호출 중 오류: ", e);
+            throw new RuntimeException("이미지 분석 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * GPT API 응답에서 content 추출
+     */
+    private String extractContentFromApiResponse(String apiResponse) {
+        try {
+            JsonNode rootNode = objectMapper.readTree(apiResponse);
+            JsonNode choicesNode = rootNode.path("choices");
+            
+            if (choicesNode.isArray() && choicesNode.size() > 0) {
+                JsonNode messageNode = choicesNode.get(0).path("message");
+                return messageNode.path("content").asText();
+            }
+            
+            throw new RuntimeException("GPT API 응답 형식이 올바르지 않습니다");
+            
+        } catch (Exception e) {
+            log.error("GPT API 응답 파싱 오류: ", e);
+            throw new RuntimeException("GPT API 응답 파싱에 실패했습니다");
+        }
+    }
+
+    /**
+     * GPT 응답에서 JSON 부분만 추출
+     */
+    private String extractJsonFromResponse(String response) {
+        int startIndex = response.indexOf("{");
+        int endIndex = response.lastIndexOf("}");
+        
+        if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
+            throw new RuntimeException("응답에서 유효한 JSON을 찾을 수 없습니다");
+        }
+        
+        return response.substring(startIndex, endIndex + 1);
+    }
+
+    /**
+     * JSON 응답 유효성 검증
+     */
+    private void validateJsonResponse(String jsonResponse) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(jsonResponse);
+            
+            String[] requiredFields = {"type", "fileDescription", "top", "middle", "base", 
+                                      "interpretation", "summary", "title"};
+            
+            for (String field : requiredFields) {
+                if (!jsonNode.has(field) || jsonNode.get(field).isNull()) {
+                    throw new RuntimeException("필수 필드가 누락되었습니다: " + field);
+                }
+            }
+            
+            String[] arrayFields = {"top", "middle", "base"};
+            for (String field : arrayFields) {
+                JsonNode arrayNode = jsonNode.get(field);
+                if (!arrayNode.isArray() || arrayNode.size() == 0) {
+                    throw new RuntimeException("배열 필드가 유효하지 않습니다: " + field);
+                }
+            }
+            
+        } catch (Exception e) {
+            log.error("JSON 유효성 검증 실패: ", e);
+            throw new RuntimeException("생성된 JSON이 유효하지 않습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Perfume 엔티티 생성
+     */
+    public Perfume createPerfumeEntity(SourceType sourceType, String url, String description) {
+        Perfume perfume = new Perfume();
+        perfume.setSourceType(sourceType);
+        perfume.setUrl(url);
+        perfume.setDescription(description);
+        return perfume;
+    }
+
+    /**
+     * 기본 설명 반환
+     */
+    private String getDefaultDescription(SourceType sourceType) {
+        if (sourceType == SourceType.AUDIO) {
+            return """
+                {
+                    "type": "AUDIO",
+                    "fileDescription": "따뜻하고 감성적인 노래로, 사랑과 그리움을 담은 아름다운 멜로디입니다.",
+                    "top": ["베르가못", "핑크페퍼", "레몬"],
+                    "middle": ["로즈", "자스민", "릴리"],
+                    "base": ["샌달우드", "머스크", "바닐라"],
+                    "interpretation": "노래의 감성적이고 로맨틱한 가사가 담긴 향수로, 부드러운 플로럴 노트가 따뜻한 우디 베이스와 어우러집니다.",
+                    "summary": "사랑과 감성을 담은 로맨틱 플로럴 향수",
+                    "title": "Lyrical Love : 가사 속 사랑"
+                }
+                """;
+        } else {
+            return """
+                {
+                    "type": "IMAGE",
+                    "fileDescription": "따뜻하고 부드러운 색감의 이미지로, 평화롭고 안정적인 분위기를 연출합니다.",
+                    "top": ["레몬", "라임", "오렌지"],
+                    "middle": ["로즈", "자스민", "라벤더"],
+                    "base": ["머스크", "우드", "바닐라"],
+                    "interpretation": "따뜻하고 부드러운 색감이 주는 평화로운 감성을 표현한 향수로, 상쾌한 시트러스 노트가 우아한 플로럴과 조화를 이룹니다.",
+                    "summary": "평화와 안정을 담은 시트러스 플로럴 향수",
+                    "title": "Golden Hour : 평화의 시간"
+                }
+                """;
+        }
+    }
+} 

--- a/src/main/java/com/umc/domain/perfume/service/PerfumeService.java
+++ b/src/main/java/com/umc/domain/perfume/service/PerfumeService.java
@@ -1,0 +1,71 @@
+package com.umc.domain.perfume.service;
+
+import com.umc.domain.perfume.dto.PerfumeResponseDto;
+import com.umc.domain.perfume.entity.Perfume;
+import com.umc.domain.perfume.entity.SourceType;
+import com.umc.domain.perfume.repository.PerfumeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class PerfumeService {
+
+    private final PerfumeRepository perfumeRepository;
+    private final PerfumeGptService perfumeGptService;
+
+    /**
+     * 향수 생성
+     */
+    public PerfumeResponseDto createPerfume(SourceType sourceType, MultipartFile file) {
+        try {
+            // 1. 가상 URL 생성 (실제 파일 저장 없음)
+            String virtualFileUrl = generateVirtualFileUrl(file);
+            
+            // 2. GPT를 통한 향수 정보 생성 (파일 직접 전달)
+            Perfume perfume = perfumeGptService.generatePerfume(sourceType, virtualFileUrl, file);
+            
+            // 3. 데이터베이스에 저장
+            Perfume savedPerfume = perfumeRepository.save(perfume);
+            
+            // 4. 응답 DTO 생성 및 반환
+            return PerfumeResponseDto.from(savedPerfume);
+            
+        } catch (Exception e) {
+            log.error("향수 생성 중 오류 발생: ", e);
+            throw new RuntimeException("향수 생성에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 가상 파일 URL 생성 (실제 파일 저장 없음)
+     */
+    private String generateVirtualFileUrl(MultipartFile file) {
+        // 파일명 생성 (UUID + 원본 확장자)
+        String originalFilename = file.getOriginalFilename();
+        String extension = originalFilename != null ? 
+            originalFilename.substring(originalFilename.lastIndexOf(".")) : ".tmp";
+        String filename = UUID.randomUUID().toString() + extension;
+        
+        // 가상 URL 반환 (실제 파일 저장 없음)
+        return "/virtual/" + filename;
+    }
+
+    /**
+     * 향수 조회
+     */
+    @Transactional(readOnly = true)
+    public PerfumeResponseDto getPerfume(Long id) {
+        Perfume perfume = perfumeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("향수를 찾을 수 없습니다: " + id));
+        
+        return PerfumeResponseDto.from(perfume);
+    }
+}

--- a/src/main/java/com/umc/global/config/WebConfig.java
+++ b/src/main/java/com/umc/global/config/WebConfig.java
@@ -1,8 +1,11 @@
 package com.umc.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -22,5 +25,15 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns("/**")
                 // 인터셉터가 실행되지 않을 경로를 설정하는 필터
                 .excludePathPatterns("/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**");
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 } 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,13 @@ spring:
   thymeleaf:
     cache: false
 
+  # 파일 업로드 설정
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+      enabled: true
+
 server:
   port: 8080
 jwt:


### PR DESCRIPTION


## 📌 PR 요약
Jackson LocalDateTime 직렬화 오류 해결 및 음악 파일 STT 기반 향수 생성 기능 구현
(Jackson JSR310 모듈 설정으로 LocalDateTime 직렬화 문제 해결, OpenAI Whisper API를 활용한 음악 가사 분석 기반 향수 레시피 생성 기능 추가)
---

## 📑 작업 내용

Jackson LocalDateTime 직렬화 오류 해결

WebConfig에 ObjectMapper Bean 설정 추가 (JavaTimeModule 등록)
ApiResponse 클래스에 @JsonFormat 어노테이션 추가
LocalDateTime 타입의 timestamp 필드 직렬화 문제 해결


OpenAI Whisper API 연동

STT(Speech-to-Text) 기능 구현으로 음악 파일에서 가사 추출
multipart/form-data 형식으로 Whisper API 호출
한국어 우선 설정 및 자동 언어 감지 지원


가사 분석 기반 향수 생성 로직 구현

추출된 가사의 감정, 분위기, 테마 분석 프롬프트 설계
감정-향료 매핑 시스템 구축 (기쁨→시트러스, 사랑→플로럴, 그리움→우디 등)
계절감, 색채감, 시간대를 고려한 세밀한 향수 레시피 생성


에러 처리 및 폴백 메커니즘

STT 실패 시 적절한 예외 처리 및 에러 메시지
API 호출 실패 시 기본 향수 레시피 제공
상세한 로깅으로 디버깅 지원 강화


설정 파일 업데이트

application.yml에 OpenAI Transcription API URL 추가
multipart 파일 업로드 최대 크기 25MB로 설정 (Whisper API 제한)
Jackson 직렬화 설정 추가

## 💡 추가 참고 사항
주요 변경 사항:

Jackson 설정: LocalDateTime 직렬화 문제로 인한 500 에러가 완전히 해결되었습니다.
API 호출 흐름 변경: 기존의 직접 오디오 입력 방식에서 STT → 텍스트 분석 방식으로 변경
비용 효율성: Whisper API(저렴) + GPT-4o-mini(텍스트) 조합으로 비용 최적화

테스트 방법:

가사가 포함된 음악 파일 (MP3, WAV 등) 업로드
STT로 가사 추출 → 감정 분석 → 향수 레시피 생성 과정 확인
다양한 장르의 음악으로 테스트 (발라드, 팝, R&B 등)
가사가 없는 순수 인스트루멘털 음악은 STT 결과가 제한적일 수 있음
OpenAI API 사용량 모니터링 필요 (STT + GPT 이중 호출)


