### PR TITLE
Feat/get my reviews

### DIFF
--- a/src/main/java/com/umc/auth/Jwt/JwtProvider.java
+++ b/src/main/java/com/umc/auth/Jwt/JwtProvider.java
@@ -21,7 +21,7 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String secretKey;
 
-    private final long expirationMillis = 1000 * 60 * 60; // 1시간
+    private final long expirationMillis = 1000L * 60 * 60 * 24 * 30; // 30일
 
     public String generateToken(User user) {
         Date now = new Date();

--- a/src/main/java/com/umc/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/domain/review/controller/ReviewController.java
@@ -6,10 +6,8 @@ import com.umc.domain.review.dto.ReviewRequestDTO;
 import com.umc.domain.review.dto.ReviewResponseDTO;
 import com.umc.domain.review.service.ReviewService;
 import com.umc.global.exception.ErrorCode;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,7 +25,7 @@ public class ReviewController {
     public ResponseEntity<ApiResponse<ReviewResponseDTO.CreateReviewReponseDTO>> createReview(
             @PathVariable Long perfumeId,
             @RequestHeader("Authorization") String token,
-            @RequestBody ReviewRequestDTO.CreatReviewRequestDTO request
+            @RequestBody ReviewRequestDTO.CreateReviewRequestDTO request
     ) {
 
         /*

--- a/src/main/java/com/umc/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/domain/review/controller/ReviewController.java
@@ -1,13 +1,19 @@
 package com.umc.domain.review.controller;
 
 import com.umc.auth.Jwt.JwtProvider;
+import com.umc.auth.util.JwtUtil;
 import com.umc.common.response.ApiResponse;
 import com.umc.domain.review.dto.ReviewRequestDTO;
 import com.umc.domain.review.dto.ReviewResponseDTO;
 import com.umc.domain.review.service.ReviewService;
+import com.umc.domain.user.entity.User;
 import com.umc.global.exception.ErrorCode;
 import io.jsonwebtoken.JwtException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,61 +22,57 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/reviews")
 @RequiredArgsConstructor
+@Slf4j
 public class ReviewController {
 
     private final ReviewService reviewService;
-    private final JwtProvider jwtTokenProvider;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/{perfumeId}")
+    @Operation(
+            summary = "리뷰 생성",
+            description = "특정 향수에 대한 리뷰를 작성합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
     public ResponseEntity<ApiResponse<ReviewResponseDTO.CreateReviewReponseDTO>> createReview(
             @PathVariable Long perfumeId,
-            @RequestHeader("Authorization") String token,
-            @RequestBody ReviewRequestDTO.CreateReviewRequestDTO request
+            @RequestBody ReviewRequestDTO.CreateReviewRequestDTO request,
+            HttpServletRequest httpRequest
     ) {
+        String authorization = httpRequest.getHeader("Authorization");
+        log.info("리뷰 생성 요청 - perfumeId: {}, Authorization: {}", perfumeId, authorization);
 
-        /*
-        // 1. 향수 존재 여부 확인 -> 향수 엔티티 추가시 다시
-        if (!perfumeRepository.existsById(perfumeId)) {
-            return ResponseEntity.status(ErrorCode.PERFUME_NOT_FOUND.getStatus()).build();
-        }*/
-
-        // 2. JWT 유효성 검사 및 사용자 ID 추출
-        String parsedToken = token.replace("Bearer ", "");
-        Long userId;
-        try {
-            userId = jwtTokenProvider.getUserId(parsedToken);
-        } catch (JwtException | IllegalArgumentException e) {
-            return ResponseEntity.status(ErrorCode.TOKEN_INVALID.getStatus()).build();
+        if (authorization == null || authorization.trim().isEmpty()) {
+            throw new RuntimeException("Authorization 헤더가 없습니다. 헤더를 확인해주세요.");
         }
 
-        ReviewResponseDTO.CreateReviewReponseDTO result = reviewService.createReview(perfumeId, userId, request);
-
+        User user = jwtUtil.getUserFromHeader(authorization);
+        ReviewResponseDTO.CreateReviewReponseDTO result = reviewService.createReview(perfumeId, user.getId(), request);
         return ResponseEntity.ok(ApiResponse.success("리뷰가 성공적으로 등록되었습니다.", result));
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<List<ReviewResponseDTO.MyReviewDTO>>> getMyReviews(
-            @RequestHeader("Authorization") String token
-    ) {
-        String parsedToken = token.replace("Bearer ", "");
-        Long userId;
-        try {
-            userId = jwtTokenProvider.getUserId(parsedToken);
-        } catch (JwtException | IllegalArgumentException e) {
-            return ResponseEntity.status(ErrorCode.TOKEN_INVALID.getStatus()).build();
+    @Operation(summary = "내가 작성한 리뷰 목록 조회", security = @SecurityRequirement(name = "bearerAuth"))
+    public ResponseEntity<ApiResponse<List<ReviewResponseDTO.MyReviewDTO>>> getMyReviews(HttpServletRequest httpRequest) {
+        String authorization = httpRequest.getHeader("Authorization");
+        log.info("내 리뷰 조회 요청 - Authorization: {}", authorization);
+
+        if (authorization == null || authorization.trim().isEmpty()) {
+            throw new RuntimeException("Authorization 헤더가 없습니다. 헤더를 확인해주세요.");
         }
 
-        List<ReviewResponseDTO.MyReviewDTO> result = reviewService.getMyReviews(userId);
+        User user = jwtUtil.getUserFromHeader(authorization);
+        List<ReviewResponseDTO.MyReviewDTO> result = reviewService.getMyReviews(user.getId());
         return ResponseEntity.ok(ApiResponse.success("내가 작성한 리뷰 목록 조회 성공", result));
     }
 
     @GetMapping("/{perfumeId}")
+    @Operation(summary = "특정 향수 리뷰 목록 조회")
     public ResponseEntity<ApiResponse<List<ReviewResponseDTO.ReviewSimpleDTO>>> getReviewsByPerfume(
             @PathVariable Long perfumeId) {
+
+        log.info("향수 리뷰 목록 조회 요청 - perfumeId: {}", perfumeId);
         List<ReviewResponseDTO.ReviewSimpleDTO> result = reviewService.getReviewsByPerfumeId(perfumeId);
-
-        //에러처리 나중에 추가 예정
-
         return ResponseEntity.ok(ApiResponse.success("리뷰 목록 조회 성공", result));
     }
 }

--- a/src/main/java/com/umc/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/umc/domain/review/converter/ReviewConverter.java
@@ -1,17 +1,14 @@
 package com.umc.domain.review.converter;
 
 
-import com.umc.domain.perfume.entity.Perfume;
 import com.umc.domain.review.dto.ReviewRequestDTO;
 import com.umc.domain.review.dto.ReviewResponseDTO;
 import com.umc.domain.review.entity.Review;
 import com.umc.domain.user.entity.User;
 
-import java.util.Optional;
-
 public class ReviewConverter {
 
-    public static Review toEntity(Long perfumeId, Long userId, ReviewRequestDTO.CreatReviewRequestDTO request) {
+    public static Review toEntity(Long perfumeId, Long userId, ReviewRequestDTO.CreateReviewRequestDTO request) {
         return Review.builder()
                 .perfumeId(perfumeId)
                 .userId(userId)

--- a/src/main/java/com/umc/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/umc/domain/review/dto/ReviewRequestDTO.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor
 public class ReviewRequestDTO {
@@ -16,7 +14,7 @@ public class ReviewRequestDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CreatReviewRequestDTO {
+    public static class CreateReviewRequestDTO {
         private String description;
     }
 }

--- a/src/main/java/com/umc/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/domain/review/service/ReviewService.java
@@ -9,13 +9,11 @@ import com.umc.domain.review.entity.Review;
 import com.umc.domain.review.repository.ReviewRepository;
 import com.umc.domain.user.entity.User;
 import com.umc.domain.user.repository.UserRepository;
-import com.umc.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,7 +25,7 @@ public class ReviewService {
     private final PerfumeRepository perfumeRepository;
 
     @Transactional
-    public ReviewResponseDTO.CreateReviewReponseDTO createReview(Long perfumeId, Long userId, ReviewRequestDTO.CreatReviewRequestDTO request) {
+    public ReviewResponseDTO.CreateReviewReponseDTO createReview(Long perfumeId, Long userId, ReviewRequestDTO.CreateReviewRequestDTO request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 


### PR DESCRIPTION
📌 PR 요약

리뷰 컨트롤러에서 JWT 인증 방식 개선 및 토큰 유효기간을 30일로 연장하였습니다.

📑 작업 내용

1. ReviewController에서 Authorization 헤더를 HttpServletRequest로 받아 JwtUtil을 통해 사용자 정보 추출
2. 중복되는 토큰 파싱 및 예외 처리 로직 제거 → JwtUtil.getUserFromHeader()로 통일
3. JwtUtil 내부 토큰 생성 시 유효기간을 기존보다 늘려 30일로 설정

💡 추가 참고 사항

기존 token.replace("Bearer ", "") 방식은 제거했으며, 헤더 누락 시 예외를 던짐
유효기간 변경은 사용자 경험 개선 목적이며, refresh token 없이 운영되는 점을 고려함