### PR TITLE
feat: 내 닉네임 조회 api

### DIFF
--- a/src/main/java/com/umc/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/domain/user/controller/UserController.java
@@ -1,0 +1,54 @@
+package com.umc.domain.user.controller;
+
+import com.umc.auth.util.JwtUtil;
+import com.umc.common.response.ApiResponse;
+import com.umc.domain.user.converter.UserConverter;
+import com.umc.domain.user.dto.UserResponseDTO;
+import com.umc.domain.user.entity.User;
+import com.umc.domain.user.repository.UserRepository;
+import com.umc.global.exception.BusinessException;
+import com.umc.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "유저 API", description = "유저 정보 관련 API")
+@Slf4j
+public class UserController {
+
+    private final JwtUtil jwtUtil;
+
+    @GetMapping("/me")
+    @Operation(summary = "자신의 닉네임 조회", description = "JWT 토큰을 기반으로 현재 유저의 닉네임을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    public ResponseEntity<ApiResponse<UserResponseDTO.MyNameDTO>> getMyNickname(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        log.info("닉네임 조회 요청 - Authorization: {}", authorization);
+
+        if (authorization == null || authorization.trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.TOKEN_INVALID, "Authorization 헤더가 없습니다.");
+        }
+
+        User user = jwtUtil.getUserFromHeader(authorization);
+        UserResponseDTO.MyNameDTO response = UserConverter.toMyNameDTO(user);
+
+        return ResponseEntity.ok(ApiResponse.success("닉네임 조회 성공", response));
+    }
+}
+
+
+

--- a/src/main/java/com/umc/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/umc/domain/user/converter/UserConverter.java
@@ -1,0 +1,14 @@
+package com.umc.domain.user.converter;
+
+import com.umc.domain.user.dto.UserResponseDTO;
+import com.umc.domain.user.entity.User;
+
+public class UserConverter {
+
+    public static UserResponseDTO.MyNameDTO toMyNameDTO(User user) {
+        return UserResponseDTO.MyNameDTO.builder()
+                .nickname(user.getNickname())
+                .build();
+    }
+}
+

--- a/src/main/java/com/umc/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/domain/user/dto/UserResponseDTO.java
@@ -1,0 +1,17 @@
+package com.umc.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyNameDTO {
+        private String nickname;
+    }
+}


### PR DESCRIPTION
📌 PR 요약

사용자 본인의 닉네임을 조회하는 API (GET /api/users/me)를 추가했습니다.
JWT 인증 기반으로 사용자 정보를 추출하여 닉네임을 반환합니다.

📑 작업 내용

UserController에 /api/users/me 엔드포인트 추가
JWT 토큰을 통해 사용자 정보 추출 (기존 jwtUtil.getUserFromHeader 방식 사용)
UserConverter에서 닉네임 응답용 DTO (MyNameDTO) 변환 추가
UserResponseDTO.MyNameDTO 클래스 생성
Swagger 명세 작성 (@Operation, @SecurityRequirement 포함)

