### PR TITLE
fix: 로그인, 리뷰 에러 처리 완성!!!

### DIFF
--- a/src/main/java/com/umc/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/auth/controller/AuthController.java
@@ -37,6 +37,15 @@ public class AuthController {
     })
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
+
+        if (request.nickname() == null || request.nickname().trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.LOGIN_NICKNAME_EMPTY);
+        }
+
+        if (request.password() == null || request.password().trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.LOGIN_PASSWORD_EMPTY);
+        }
+
         User user = userRepository.findByNickname(request.nickname())
                 .orElseGet(() -> {
                     // 없으면 자동 회원가입

--- a/src/main/java/com/umc/auth/dto/LoginRequest.java
+++ b/src/main/java/com/umc/auth/dto/LoginRequest.java
@@ -3,4 +3,4 @@ package com.umc.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 
 // 요청 DTO
-public record LoginRequest(@NotBlank String nickname, @NotBlank String password) {}
+public record LoginRequest(String nickname, String password) {}

--- a/src/main/java/com/umc/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/domain/review/controller/ReviewController.java
@@ -3,11 +3,14 @@ package com.umc.domain.review.controller;
 import com.umc.auth.Jwt.JwtProvider;
 import com.umc.auth.util.JwtUtil;
 import com.umc.common.response.ApiResponse;
+import com.umc.domain.perfume.entity.Perfume;
+import com.umc.domain.perfume.repository.PerfumeRepository;
 import com.umc.domain.review.dto.ReviewRequestDTO;
 import com.umc.domain.review.dto.ReviewResponseDTO;
 import com.umc.domain.review.service.ReviewService;
 import com.umc.domain.user.entity.User;
 import com.umc.global.config.SwaggerConfig;
+import com.umc.global.exception.BusinessException;
 import com.umc.global.exception.ErrorCode;
 import io.jsonwebtoken.JwtException;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -29,6 +32,7 @@ public class ReviewController {
 
     private final ReviewService reviewService;
     private final JwtUtil jwtUtil;
+    private final PerfumeRepository perfumeRepository;
 
     @PostMapping("/{perfumeId}")
     @Operation(
@@ -39,7 +43,6 @@ public class ReviewController {
     @SwaggerConfig.ApiErrorExamples({
             ErrorCode.TOKEN_INVALID,
             ErrorCode.PERFUME_NOT_FOUND,
-            ErrorCode.USER_NOT_FOUND,
             ErrorCode.PERFUME_INVALID_INPUT_VALUE,
             ErrorCode.REVIEW_DESCRIPTION_EMPTY,
             ErrorCode.INTERNAL_SERVER_ERROR
@@ -53,10 +56,11 @@ public class ReviewController {
         log.info("리뷰 생성 요청 - perfumeId: {}, Authorization: {}", perfumeId, authorization);
 
         if (authorization == null || authorization.trim().isEmpty()) {
-            throw new RuntimeException("Authorization 헤더가 없습니다. 헤더를 확인해주세요.");
+            throw new BusinessException(ErrorCode.TOKEN_INVALID);
         }
 
         User user = jwtUtil.getUserFromHeader(authorization);
+
         ReviewResponseDTO.CreateReviewReponseDTO result = reviewService.createReview(perfumeId, user.getId(), request);
         return ResponseEntity.ok(ApiResponse.success("리뷰가 성공적으로 등록되었습니다.", result));
     }
@@ -73,7 +77,7 @@ public class ReviewController {
         log.info("내 리뷰 조회 요청 - Authorization: {}", authorization);
 
         if (authorization == null || authorization.trim().isEmpty()) {
-            throw new RuntimeException("Authorization 헤더가 없습니다. 헤더를 확인해주세요.");
+            throw new BusinessException(ErrorCode.TOKEN_INVALID);
         }
 
         User user = jwtUtil.getUserFromHeader(authorization);


### PR DESCRIPTION
🔗 관련 이슈

#에러처리

⸻

📌 PR 요약
	•	전반적인 API 에러 응답 형식 통일
	•	사용자 정의 ErrorCode를 기반으로 한 커스텀 예외 처리 적용
	•	Swagger 문서에 에러 응답 예시 노출을 위한 어노테이션 적용

⸻

📑 작업 내용
	1.	BusinessException, GlobalExceptionHandler 구현
	•	모든 예외를 ApiResponse 포맷으로 반환
	•	에러 응답 시 status, code, message 일관되게 처리
	2.	Swagger 예외 문서화 어노테이션 적용
	•	@SwaggerConfig.ApiErrorExamples({...}) 방식으로 각 API별 예외 응답 예시 표시
	•	ErrorCode 기반으로 설명 및 스키마 적용
	3.	Review 관련 에러 처리
	•	리뷰 생성 시 description 값이 비어있으면 REVIEW_DESCRIPTION_EMPTY 에러 발생
	•	존재하지 않는 사용자/향수에 대한 접근 시 USER_NOT_FOUND, PERFUME_NOT_FOUND 반환
	4.	로그인 요청값 검증 방식 변경
	•	DTO에서 @NotBlank 제거 → 컨트롤러 내부에서 수동 검증 (nickname, password)
	•	비어있을 경우 LOGIN_NICKNAME_EMPTY, LOGIN_PASSWORD_EMPTY 반환
	•	기존 유저의 비밀번호 불일치 시 DUPLICATE_NICKNAME 에러 처리
	5.	리뷰 목록 조회 시 향수 존재 여부 검증
	•	getReviewsByPerfumeId() 내에서 perfumeId 존재 여부 확인
	•	현재는 해당 검증 제거 (사용자 요청)
	6.	토큰 없는 요청 시 예외 처리 강화
	•	리뷰 API에서 Authorization 헤더 유무 체크 및 TOKEN_INVALID 에러 반환
