### PR TITLE
Feat/perfume error

### DIFF
--- a/src/main/java/com/umc/domain/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/umc/domain/perfume/controller/PerfumeController.java
@@ -7,6 +7,9 @@ import com.umc.domain.perfume.entity.SourceType;
 import com.umc.domain.perfume.service.PerfumeService;
 import java.util.List;
 import com.umc.domain.user.entity.User;
+import com.umc.global.config.SwaggerConfig.ApiErrorExample;
+import com.umc.global.config.SwaggerConfig.ApiErrorExamples;
+import com.umc.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -44,19 +47,15 @@ public class PerfumeController {
             responseCode = "200",
             description = "향수 생성 성공",
             content = @Content(schema = @Schema(implementation = PerfumeResponseDto.class))
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청 (파일 형식 오류, 크기 초과 등)"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401",
-            description = "인증 실패 (JWT 토큰 오류)"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "500",
-            description = "서버 오류"
         )
+    })
+    @ApiErrorExamples({
+        ErrorCode.PERFUME_FILE_EMPTY,
+        ErrorCode.PERFUME_FILE_SIZE_EXCEEDED,
+        ErrorCode.PERFUME_INVALID_FILE_TYPE,
+        ErrorCode.PERFUME_CREATION_FAILED,
+        ErrorCode.TOKEN_INVALID,
+        ErrorCode.USER_NOT_FOUND
     })
     public ApiResponse<PerfumeResponseDto> createPerfume(
             @Parameter(description = "소스 타입 (AUDIO 또는 IMAGE)", required = true)
@@ -67,42 +66,21 @@ public class PerfumeController {
             
             HttpServletRequest request) {
         
-        try {
-            // Authorization 헤더 추출 및 검증
-            String authorization = request.getHeader("Authorization");
-            log.info("향수 생성 요청 - sourceType: {}, fileName: {}, fileSize: {}MB", 
-                    sourceType, 
-                    file.getOriginalFilename(),
-                    String.format("%.2f", file.getSize() / (1024.0 * 1024.0)));
-            
-            if (authorization == null || authorization.trim().isEmpty()) {
-                log.warn("Authorization 헤더가 없는 요청");
-                throw new RuntimeException("Authorization 헤더가 필요합니다. Bearer 토큰을 포함해주세요.");
-            }
-            
-            if (!authorization.startsWith("Bearer ")) {
-                log.warn("잘못된 Authorization 헤더 형식: {}", authorization);
-                throw new RuntimeException("Authorization 헤더는 'Bearer <token>' 형식이어야 합니다.");
-            }
-            
-            // JWT 토큰에서 사용자 정보 추출
-            User user = jwtUtil.getUserFromHeader(authorization);
-            log.info("인증된 사용자: {} (ID: {})", user.getNickname(), user.getId());
-            
-            // 향수 생성
-            PerfumeResponseDto response = perfumeService.createPerfume(sourceType, file, user);
-            
-            log.info("향수 생성 성공 - 향수 ID: {}, 사용자: {}", response.getId(), user.getNickname());
-            
-            return ApiResponse.success(response);
-            
-        } catch (RuntimeException e) {
-            log.error("향수 생성 실패 - 사용자 오류: {}", e.getMessage());
-            throw e; // RuntimeException은 그대로 던져서 GlobalExceptionHandler에서 처리
-        } catch (Exception e) {
-            log.error("향수 생성 실패 - 시스템 오류: ", e);
-            throw new RuntimeException("향수 생성 중 예상하지 못한 오류가 발생했습니다.");
-        }
+        log.info("향수 생성 요청 - sourceType: {}, fileName: {}, fileSize: {}MB", 
+                sourceType, 
+                file.getOriginalFilename(),
+                String.format("%.2f", file.getSize() / (1024.0 * 1024.0)));
+        
+        // JWT 토큰에서 사용자 정보 추출
+        User user = jwtUtil.getUserFromHeader(request.getHeader("Authorization"));
+        log.info("인증된 사용자: {} (ID: {})", user.getNickname(), user.getId());
+        
+        // 향수 생성
+        PerfumeResponseDto response = perfumeService.createPerfume(sourceType, file, user);
+        
+        log.info("향수 생성 성공 - 향수 ID: {}, 사용자: {}", response.getId(), user.getNickname());
+        
+        return ApiResponse.success(response);
     }
 
     @GetMapping("/{id}")
@@ -115,37 +93,25 @@ public class PerfumeController {
             responseCode = "200",
             description = "향수 조회 성공",
             content = @Content(schema = @Schema(implementation = PerfumeResponseDto.class))
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "향수를 찾을 수 없음"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 ID 형식"
         )
+    })
+    @ApiErrorExamples({
+        ErrorCode.PERFUME_NOT_FOUND,
+        ErrorCode.PERFUME_INVALID_INPUT_VALUE
     })
     public ApiResponse<PerfumeResponseDto> getPerfume(
             @Parameter(description = "향수 ID", required = true)
             @PathVariable Long id) {
         
-        try {
-            log.info("향수 조회 요청 - id: {}", id);
-            
-            PerfumeResponseDto response = perfumeService.getPerfume(id);
-            
-            log.info("향수 조회 성공 - id: {}", id);
-            
-            return ApiResponse.success(response);
-            
-        } catch (RuntimeException e) {
-            log.error("향수 조회 실패 - ID: {}, 오류: {}", id, e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("향수 조회 실패 - 시스템 오류: ", e);
-            throw new RuntimeException("향수 조회 중 예상하지 못한 오류가 발생했습니다.");
-        }
+        log.info("향수 조회 요청 - id: {}", id);
+        
+        PerfumeResponseDto response = perfumeService.getPerfume(id);
+        
+        log.info("향수 조회 성공 - id: {}", id);
+        
+        return ApiResponse.success(response);
     }
+    
 
     @GetMapping("/user/{userId}")
     @Operation(
@@ -157,37 +123,25 @@ public class PerfumeController {
             responseCode = "200",
             description = "향수 목록 조회 성공",
             content = @Content(schema = @Schema(implementation = PerfumeResponseDto.class))
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "사용자를 찾을 수 없음"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 사용자 ID 형식"
         )
+    })
+    @ApiErrorExamples({
+        ErrorCode.USER_NOT_FOUND,
+        ErrorCode.INVALID_INPUT_VALUE
     })
     public ApiResponse<List<PerfumeResponseDto>> getUserPerfumes(
             @Parameter(description = "사용자 ID", required = true)
             @PathVariable Long userId) {
         
-        try {
-            log.info("사용자 향수 목록 조회 요청 - userId: {}", userId);
-            
-            List<PerfumeResponseDto> response = perfumeService.getUserPerfumes(userId);
-            
-            log.info("사용자 향수 목록 조회 성공 - userId: {}, 향수 개수: {}", userId, response.size());
-            
-            return ApiResponse.success(response);
-            
-        } catch (RuntimeException e) {
-            log.error("사용자 향수 목록 조회 실패 - userId: {}, 오류: {}", userId, e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("사용자 향수 목록 조회 실패 - 시스템 오류: ", e);
-            throw new RuntimeException("향수 목록 조회 중 예상하지 못한 오류가 발생했습니다.");
-        }
+        log.info("사용자 향수 목록 조회 요청 - userId: {}", userId);
+        
+        List<PerfumeResponseDto> response = perfumeService.getUserPerfumes(userId);
+        
+        log.info("사용자 향수 목록 조회 성공 - userId: {}, 향수 개수: {}", userId, response.size());
+        
+        return ApiResponse.success(response);
     }
+    
 
     @GetMapping("/my")
     @Operation(
@@ -200,41 +154,23 @@ public class PerfumeController {
             responseCode = "200",
             description = "내 향수 목록 조회 성공",
             content = @Content(schema = @Schema(implementation = PerfumeResponseDto.class))
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401",
-            description = "인증 실패"
         )
     })
+    @ApiErrorExample(ErrorCode.TOKEN_INVALID)
     public ApiResponse<List<PerfumeResponseDto>> getMyPerfumes(HttpServletRequest request) {
         
-        try {
-            // Authorization 헤더 추출 및 검증
-            String authorization = request.getHeader("Authorization");
-            
-            if (authorization == null || authorization.trim().isEmpty()) {
-                throw new RuntimeException("Authorization 헤더가 필요합니다.");
-            }
-            
-            // JWT 토큰에서 사용자 정보 추출
-            User user = jwtUtil.getUserFromHeader(authorization);
-            
-            log.info("내 향수 목록 조회 요청 - 사용자: {} (ID: {})", user.getNickname(), user.getId());
-            
-            List<PerfumeResponseDto> response = perfumeService.getUserPerfumes(user.getId());
-            
-            log.info("내 향수 목록 조회 성공 - 사용자: {}, 향수 개수: {}", user.getNickname(), response.size());
-            
-            return ApiResponse.success(response);
-            
-        } catch (RuntimeException e) {
-            log.error("내 향수 목록 조회 실패 - 오류: {}", e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("내 향수 목록 조회 실패 - 시스템 오류: ", e);
-            throw new RuntimeException("내 향수 목록 조회 중 예상하지 못한 오류가 발생했습니다.");
-        }
+        // JWT 토큰에서 사용자 정보 추출
+        User user = jwtUtil.getUserFromHeader(request.getHeader("Authorization"));
+        
+        log.info("내 향수 목록 조회 요청 - 사용자: {} (ID: {})", user.getNickname(), user.getId());
+        
+        List<PerfumeResponseDto> response = perfumeService.getUserPerfumes(user.getId());
+        
+        log.info("내 향수 목록 조회 성공 - 사용자: {}, 향수 개수: {}", user.getNickname(), response.size());
+        
+        return ApiResponse.success(response);
     }
+    
 
     @DeleteMapping("/{id}")
     @Operation(
@@ -246,19 +182,13 @@ public class PerfumeController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200",
             description = "향수 삭제 성공"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "향수를 찾을 수 없음"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "삭제 권한 없음 (본인이 생성한 향수가 아님)"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401",
-            description = "인증 실패"
         )
+    })
+    @ApiErrorExamples({
+        ErrorCode.PERFUME_NOT_FOUND,
+        ErrorCode.PERFUME_ACCESS_DENIED,
+        ErrorCode.PERFUME_INVALID_INPUT_VALUE,
+        ErrorCode.TOKEN_INVALID
     })
     public ApiResponse<String> deletePerfume(
             @Parameter(description = "향수 ID", required = true)
@@ -266,34 +196,19 @@ public class PerfumeController {
             
             HttpServletRequest request) {
         
-        try {
-            log.info("향수 삭제 요청 - id: {}", id);
-            
-            // Authorization 헤더 추출 및 검증
-            String authorization = request.getHeader("Authorization");
-            
-            if (authorization == null || authorization.trim().isEmpty()) {
-                throw new RuntimeException("Authorization 헤더가 필요합니다.");
-            }
-            
-            // JWT 토큰에서 사용자 정보 추출
-            User user = jwtUtil.getUserFromHeader(authorization);
-            log.info("향수 삭제 요청 - 향수 ID: {}, 사용자: {} (ID: {})", id, user.getNickname(), user.getId());
-            
-            perfumeService.deletePerfume(id, user);
-            
-            log.info("향수 삭제 성공 - 향수 ID: {}, 사용자: {}", id, user.getNickname());
-            
-            return ApiResponse.success("향수가 성공적으로 삭제되었습니다.");
-            
-        } catch (RuntimeException e) {
-            log.error("향수 삭제 실패 - ID: {}, 오류: {}", id, e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("향수 삭제 실패 - 시스템 오류: ", e);
-            throw new RuntimeException("향수 삭제 중 예상하지 못한 오류가 발생했습니다.");
-        }
+        log.info("향수 삭제 요청 - id: {}", id);
+        
+        // JWT 토큰에서 사용자 정보 추출
+        User user = jwtUtil.getUserFromHeader(request.getHeader("Authorization"));
+        log.info("향수 삭제 요청 - 향수 ID: {}, 사용자: {} (ID: {})", id, user.getNickname(), user.getId());
+        
+        perfumeService.deletePerfume(id, user);
+        
+        log.info("향수 삭제 성공 - 향수 ID: {}, 사용자: {}", id, user.getNickname());
+        
+        return ApiResponse.success("향수가 성공적으로 삭제되었습니다.");
     }
+    
 
     @GetMapping("/recommend")
     @Operation(
@@ -305,41 +220,29 @@ public class PerfumeController {
             responseCode = "200",
             description = "향수 추천 성공",
             content = @Content(schema = @Schema(implementation = PerfumeResponseDto.class))
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청 (잘못된 sourceType)"
         )
     })
+    @ApiErrorExample(ErrorCode.PERFUME_INVALID_SOURCE_TYPE)
     public ApiResponse<List<PerfumeResponseDto>> recommendPerfume(
             @Parameter(description = "소스 타입 (AUDIO 또는 IMAGE)", required = true)
             @RequestParam("sourceType") String sourceType) {
-        
-        try {
-            log.info("향수 추천 요청 - sourceType: {}", sourceType);
-            
-            // sourceType을 내부 enum으로 변환
-            SourceType internalSourceType;
-            if ("AUDIO".equalsIgnoreCase(sourceType)) {
-                internalSourceType = SourceType.RECOMMEND_AUDIO;
-            } else if ("IMAGE".equalsIgnoreCase(sourceType)) {
-                internalSourceType = SourceType.RECOMMEND_IMAGE;
-            } else {
-                throw new RuntimeException("잘못된 sourceType입니다. AUDIO 또는 IMAGE만 사용 가능합니다.");
-            }
-            
-            List<PerfumeResponseDto> response = perfumeService.recommendPerfumes(internalSourceType);
-            
-            log.info("향수 추천 성공 - sourceType: {}, 추천 개수: {}", sourceType, response.size());
-            
-            return ApiResponse.success(response);
-            
-        } catch (RuntimeException e) {
-            log.error("향수 추천 실패 - sourceType: {}, 오류: {}", sourceType, e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("향수 추천 실패 - 시스템 오류: ", e);
-            throw new RuntimeException("향수 추천 중 예상하지 못한 오류가 발생했습니다.");
+
+        log.info("향수 추천 요청 - sourceType: {}", sourceType);
+
+        // sourceType을 내부 enum으로 변환
+        SourceType internalSourceType;
+        if ("AUDIO".equalsIgnoreCase(sourceType)) {
+            internalSourceType = SourceType.RECOMMEND_AUDIO;
+        } else if ("IMAGE".equalsIgnoreCase(sourceType)) {
+            internalSourceType = SourceType.RECOMMEND_IMAGE;
+        } else {
+            throw new RuntimeException("잘못된 sourceType입니다. AUDIO 또는 IMAGE만 사용 가능합니다.");
         }
+
+        List<PerfumeResponseDto> response = perfumeService.recommendPerfumes(internalSourceType);
+
+        log.info("향수 추천 성공 - sourceType: {}, 추천 개수: {}", sourceType, response.size());
+
+        return ApiResponse.success(response);
     }
-}
+}   

--- a/src/main/java/com/umc/domain/perfume/service/PerfumeService.java
+++ b/src/main/java/com/umc/domain/perfume/service/PerfumeService.java
@@ -6,6 +6,8 @@ import com.umc.domain.perfume.entity.SourceType;
 import com.umc.domain.perfume.repository.PerfumeRepository;
 import com.umc.domain.user.entity.User;
 import com.umc.domain.user.repository.UserRepository;
+import com.umc.global.exception.BusinessException;
+import com.umc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,7 +35,7 @@ public class PerfumeService {
         try {
             // 0. 사용자 존재 확인 (Foreign Key 제약 조건 해결)
             User existingUser = userRepository.findById(user.getId())
-                    .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다: " + user.getId()));
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
             
             // 1. 파일 유효성 검증
             validateFile(file, sourceType);
@@ -67,9 +69,11 @@ public class PerfumeService {
             PerfumeResponseDto dto = PerfumeResponseDto.from(savedPerfume);
             return dto.withClientSourceType(convertToClientSourceType(savedPerfume.getSourceType()));
             
+        } catch (BusinessException e) {
+            throw e; // BusinessException은 그대로 전파
         } catch (Exception e) {
             log.error("향수 생성 중 오류 발생: ", e);
-            throw new RuntimeException("향수 생성에 실패했습니다: " + e.getMessage());
+            throw new BusinessException(ErrorCode.PERFUME_CREATION_FAILED);
         }
     }
 
@@ -79,28 +83,28 @@ public class PerfumeService {
     private void validateFile(MultipartFile file, SourceType sourceType) {
         // 파일 존재 검증
         if (file == null || file.isEmpty()) {
-            throw new RuntimeException("파일이 비어있습니다.");
+            throw new BusinessException(ErrorCode.PERFUME_FILE_EMPTY);
         }
 
         // 파일 크기 검증
         long maxSize = sourceType == SourceType.AUDIO ? 25 * 1024 * 1024 : 20 * 1024 * 1024; // 25MB for audio, 20MB for image
         if (file.getSize() > maxSize) {
-            throw new RuntimeException("파일 크기가 너무 큽니다. " + (maxSize / (1024 * 1024)) + "MB 이하로 업로드해주세요.");
+            throw new BusinessException(ErrorCode.PERFUME_FILE_SIZE_EXCEEDED);
         }
 
         // 파일 형식 검증
         String contentType = file.getContentType();
         if (contentType == null) {
-            throw new RuntimeException("파일 형식을 확인할 수 없습니다.");
+            throw new BusinessException(ErrorCode.PERFUME_INVALID_FILE_TYPE);
         }
 
         if (sourceType == SourceType.AUDIO) {
             if (!contentType.startsWith("audio/")) {
-                throw new RuntimeException("오디오 파일만 업로드 가능합니다. 현재 파일 형식: " + contentType);
+                throw new BusinessException(ErrorCode.PERFUME_INVALID_FILE_TYPE);
             }
         } else if (sourceType == SourceType.IMAGE) {
             if (!contentType.startsWith("image/")) {
-                throw new RuntimeException("이미지 파일만 업로드 가능합니다. 현재 파일 형식: " + contentType);
+                throw new BusinessException(ErrorCode.PERFUME_INVALID_FILE_TYPE);
             }
         }
 
@@ -118,11 +122,11 @@ public class PerfumeService {
     @Transactional(readOnly = true)
     public PerfumeResponseDto getPerfume(Long id) {
         if (id == null || id <= 0) {
-            throw new RuntimeException("유효하지 않은 향수 ID입니다: " + id);
+            throw new BusinessException(ErrorCode.PERFUME_INVALID_INPUT_VALUE);
         }
         
         Perfume perfume = perfumeRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("향수를 찾을 수 없습니다: " + id));
+                .orElseThrow(() -> new BusinessException(ErrorCode.PERFUME_NOT_FOUND));
         
         log.info("향수 조회 완료 - ID: {}, 사용자: {}", id, perfume.getUser().getNickname());
         
@@ -137,11 +141,11 @@ public class PerfumeService {
     @Transactional(readOnly = true)
     public List<PerfumeResponseDto> getUserPerfumes(Long userId) {
         if (userId == null || userId <= 0) {
-            throw new RuntimeException("유효하지 않은 사용자 ID입니다: " + userId);
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
         
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다: " + userId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         List<Perfume> perfumes = perfumeRepository.findByUserOrderByCreatedAtDesc(user);
         
@@ -161,15 +165,15 @@ public class PerfumeService {
      */
     public void deletePerfume(Long id, User user) {
         if (id == null || id <= 0) {
-            throw new RuntimeException("유효하지 않은 향수 ID입니다: " + id);
+            throw new BusinessException(ErrorCode.PERFUME_INVALID_INPUT_VALUE);
         }
         
         Perfume perfume = perfumeRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("향수를 찾을 수 없습니다: " + id));
+                .orElseThrow(() -> new BusinessException(ErrorCode.PERFUME_NOT_FOUND));
         
         // 본인이 생성한 향수인지 확인
         if (perfume.getUser() == null || !perfume.getUser().getId().equals(user.getId())) {
-            throw new RuntimeException("본인이 생성한 향수만 삭제할 수 있습니다.");
+            throw new BusinessException(ErrorCode.PERFUME_ACCESS_DENIED);
         }
         
         // 향수 삭제
@@ -183,11 +187,11 @@ public class PerfumeService {
     @Transactional(readOnly = true)
     public List<PerfumeResponseDto> recommendPerfumes(SourceType sourceType) {
         if (sourceType == null) {
-            throw new RuntimeException("sourceType이 필요합니다.");
+            throw new BusinessException(ErrorCode.PERFUME_INVALID_SOURCE_TYPE);
         }
         
         if (sourceType != SourceType.RECOMMEND_AUDIO && sourceType != SourceType.RECOMMEND_IMAGE) {
-            throw new RuntimeException("추천 API는 RECOMMEND_AUDIO 또는 RECOMMEND_IMAGE 타입만 사용 가능합니다.");
+            throw new BusinessException(ErrorCode.PERFUME_INVALID_SOURCE_TYPE);
         }
         
         // DB에서 추천 타입에 해당하는 향수들을 최대 10개 조회

--- a/src/main/java/com/umc/global/exception/ErrorCode.java
+++ b/src/main/java/com/umc/global/exception/ErrorCode.java
@@ -28,6 +28,12 @@ public enum ErrorCode {
     // 향수 관련 에러
     PERFUME_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFUME_4001", "해당 향수를 찾을 수 없습니다."),
     PERFUME_INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "PERFUME_4002", "perfumeId가 잘못된 형식입니다."),
+    PERFUME_FILE_EMPTY(HttpStatus.BAD_REQUEST, "PERFUME_4003", "파일이 비어있습니다."),
+    PERFUME_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "PERFUME_4004", "파일 크기가 제한을 초과했습니다."),
+    PERFUME_INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "PERFUME_4005", "지원하지 않는 파일 형식입니다."),
+    PERFUME_INVALID_SOURCE_TYPE(HttpStatus.BAD_REQUEST, "PERFUME_4006", "잘못된 소스 타입입니다."),
+    PERFUME_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PERFUME_5001", "향수 생성에 실패했습니다."),
+    PERFUME_ACCESS_DENIED(HttpStatus.FORBIDDEN, "PERFUME_4007", "해당 향수에 대한 접근 권한이 없습니다."),
 
     // 리뷰 관련 에러
     REVIEW_DESCRIPTION_EMPTY(HttpStatus.BAD_REQUEST, "REVIEW_4001", "리뷰 내용은 비어 있을 수 없습니다."),


### PR DESCRIPTION
---

## 📌 PR 요약

향수 모듈에 대한 체계적인 에러 처리 시스템 구축 및 Swagger API 문서화 개선을 통해 클라이언트와의 일관된 에러 응답 형식을 제공하고, 향수 조회 시 sourceType을 클라이언트 친화적으로 변환하는 기능을 구현했습니다.

---

## 📑 작업 내용

1. 향수 관련 에러 코드 추가 (ErrorCode.java)
PERFUME_FILE_EMPTY: 파일이 비어있을 때
PERFUME_FILE_SIZE_EXCEEDED: 파일 크기 제한 초과 시
PERFUME_INVALID_FILE_TYPE: 지원하지 않는 파일 형식
PERFUME_INVALID_SOURCE_TYPE: 잘못된 소스 타입
PERFUME_CREATION_FAILED: 향수 생성 실패
PERFUME_ACCESS_DENIED: 접근 권한 없음

2. PerfumeService 에러 처리 개선
모든 RuntimeException을 BusinessException으로 변경
각 에러 상황에 맞는 적절한 에러 코드 매핑
GlobalExceptionHandler를 통한 일관된 에러 응답 처리

3. PerfumeController Swagger 문서화
각 API 엔드포인트에 @ApiErrorExample 및 @ApiErrorExamples 어노테이션 추가
불필요한 try-catch 블록 제거로 코드 간소화
API별 발생 가능한 에러 상황을 Swagger 문서에 명시

4. SourceType 클라이언트 변환 기능
모든 향수 조회 API에서 DB의 RECOMMEND_AUDIO/RECOMMEND_IMAGE를 클라이언트용 AUDIO/IMAGE로 변환
createPerfume, getPerfume, getUserPerfumes, recommendPerfumes 메서드에 변환 로직 적용
일관된 클라이언트 응답 형식 제공

## 💡 추가 참고 사항

코드베이스 영향
에러 처리: GlobalExceptionHandler가 모든 BusinessException을 일관되게 처리하므로 향후 다른 모듈에서도 동일한 패턴 적용 가능
API 응답: 클라이언트에서 에러 처리가 더욱 예측 가능하고 일관됨
Swagger 문서: API 사용자가 발생 가능한 에러를 사전에 파악하여 적절한 예외 처리 구현 가능